### PR TITLE
Fix addStake issue in StakeVault contract

### DIFF
--- a/contracts/new_StakeVault.sol
+++ b/contracts/new_StakeVault.sol
@@ -95,7 +95,7 @@ contract StakeVault is Ownable {
 
         stakesByInvestor[staker].push(_currStakeId);
 
-        _poolTrackerContract.addStake(_currStakeId, poolId);
+        _poolTrackerContract.addStake(poolId, _currStakeId);
 
         // If the transfer fails, we revert and don't record the amount.
         require(


### PR DESCRIPTION
Change addStake function call in StakeVault contract to launchPoolTracker above.
_poolTrackerContract.addStake(_currStakeId, poolId); -> _poolTrackerContract.addStake(poolId, _currStakeId); 